### PR TITLE
Allows for config options to be optional

### DIFF
--- a/src/clojure/kafka/connect/event_feed/config.clj
+++ b/src/clojure/kafka/connect/event_feed/config.clj
@@ -47,8 +47,9 @@
 (defn- define
   [^ConfigDef config-def
    & {:keys [name type default-value importance documentation]
-      :or   {default-value nil}}]
-  (if default-value
+      :or   {default-value nil}
+      :as   config}]
+  (if (contains? config :default-value)
     (.define config-def name
       (configuration-type type)
       default-value


### PR DESCRIPTION
Currently if you require a configuration option with a null default (which from my understanding is possible as per https://docs.confluent.io/platform/current/installation/configuration/connect/index.html) due to how the check is done it will think that there is no default value instead.

This PR changes that logic to check if the key is there, instead of the value being null.