### PR TITLE
Add support for parsing arrays containing maps in event resource properties

### DIFF
--- a/src/clojure/kafka/connect/event_feed/utils.clj
+++ b/src/clojure/kafka/connect/event_feed/utils.clj
@@ -21,7 +21,7 @@
                      (clojure-data->java-data v))))
                (HashMap.)
                (seq x))
-    (list? x) (ArrayList. ^Collection (map clojure-data->java-data x))
+    (or (list? x) (vector? x)) (ArrayList. ^Collection (map clojure-data->java-data x))
     (set? x) (HashSet. ^Collection (map clojure-data->java-data x))
     (seq? x) (LinkedList. (map clojure-data->java-data x))
     (number? x) (Integer/parseInt (str x))


### PR DESCRIPTION
This should hopefully fix a bug we discovered with an instance that fails to parse a valid JSON event resource payload when it contains a property value including an array with a map inside.

Authors: @jordanrobinson @chris-emerson