### PR TITLE
Fixes potential max value overflow when parsing Clojure data into Java data

### DIFF
--- a/src/clojure/kafka/connect/event_feed/utils.clj
+++ b/src/clojure/kafka/connect/event_feed/utils.clj
@@ -35,7 +35,7 @@
     (LinkedList. (map clojure-data->java-data x))
 
     (number? x)
-    (Integer/parseInt (str x))
+    (Long/parseLong (str x))
 
     :else x))
 

--- a/test/unit/kafka/connect/event_feed/utils_test.clj
+++ b/test/unit/kafka/connect/event_feed/utils_test.clj
@@ -1,0 +1,11 @@
+(ns kafka.connect.event-feed.utils-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [kafka.connect.event-feed.test.logging]
+   [kafka.connect.event-feed.utils :refer [clojure-data->java-data]]))
+
+(deftest utils-parses-numbers-as-longs
+  (is (= 100
+         (clojure-data->java-data 100)))
+  (is (= (+ 1 Integer/MAX_VALUE)
+         (clojure-data->java-data (+ 1 Integer/MAX_VALUE)))))


### PR DESCRIPTION
Hello,

Please see attached commit for details. The test will fail against the current code, with the fix being to parse as Long by default. This is because `number?` encompasses both Integer and Long.

Also previously discussed in #2 - but the rebase to fix formatting errors seems to have auto-closed that PR, sorry for any confusion.

Thanks,
Jordan
