### PR TITLE
[#TELE-1541] Upgrade to Halboy 6.0.0 to use clj-http instead of HttpKit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,7 @@
 
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/tools.logging "1.1.0"]
-
-                 [halboy "5.1.1"]
+                 [halboy "6.0.0"]
                  [json-path "2.1.0"]]
 
   :profiles


### PR DESCRIPTION
As part of the investigation into #TELE-1541 we suspect that the SSL/TLS "Cannot kickstart, the connection is broken or closed" errors we were seeing in the logs happen because the maximum number of open TCP connections on TIME_WAIT is being exceeded regularly, partly due to the poll loop being called every 200ms. We suspect that ultimately this results in all of the TLS connections being terminated when this limit is reached, which would explain why we are seeing these SSL kickstart exception log entries for all connectors on a regular but intermittent basis. 

The newly released version 6.0.0 of Halboy uses clj-http as it's default HTTP client instead of HttpKit. Given that these SSL exceptions seem to relate to how the HTTP client manages its connection pool, we think it's worth upgrading to Halboy 6.0.0 to see if the clj-http client resolves these SSL exception issues.
 
[https://github.com/http-kit/http-kit/issues/324#issuecomment-417581954
](https://github.com/http-kit/http-kit/issues/324#issuecomment-417581954
)
Authors: @chris-emerson @ShanaSkydancer