### PR TITLE
Sets log level of frequent log calls to debug

### DIFF
--- a/src/clojure/kafka/connect/event_feed/task.clj
+++ b/src/clojure/kafka/connect/event_feed/task.clj
@@ -64,7 +64,7 @@
   (update-state state-atom assoc :config nil))
 
 (defn report-commit-count [state-atom]
-  (log/infof
+  (log/debugf
     "EventFeedSourceTask[name: %s] committed %s records to topic since start."
     (efc/connector-name (config state-atom))
     (records-committed state-atom)))
@@ -99,7 +99,7 @@
             (efc/connector-name config))
           [[] nil])
         (do
-          (log/infof "EventFeedSourceTask[name: %s] found %s new events."
+          (log/debugf "EventFeedSourceTask[name: %s] found %s new events."
             (efc/connector-name config)
             (count events))
           (log/debugf "EventFeedSourceTask[name: %s] new events are: %s"
@@ -131,7 +131,7 @@
         (Throwable->map t)))))
 
 (defn commit [state-atom]
-  (log/infof
+  (log/debugf
     "EventFeedSourceTask[name: %s] committed records up to offset: %s"
     (efc/connector-name (config state-atom))
     (offset state-atom)))


### PR DESCRIPTION
Hello all, hope you're doing well.

We've found that the three log calls in this PR are especially chatty, and if possible we'd like to relegate them to `debug` instead of `info` as they are outputting a considerable number of logs.

This is also getting worse for us with time the more event feed sources there are.

Please let us know if there's a different approach you'd like us to take here.

Thanks,
Jordan and Francesco